### PR TITLE
Fix AsyncLocal issue by following exactly HttpContextAccessor usage.

### DIFF
--- a/TestAsyncLocalMiddleware/Infrastructure/ContextBuilder.cs
+++ b/TestAsyncLocalMiddleware/Infrastructure/ContextBuilder.cs
@@ -24,9 +24,12 @@ namespace TestAsyncLocalMiddleware.Infrastructure
         {
 
             var contextCollection = new Dictionary<string, IEnumerable<string>>();
-            foreach (var kv in securityTokenAccessor.ContextItems)
+            if (securityTokenAccessor.ContextItems != null)
             {
-                contextCollection.Add(kv.Key, new[] { kv.Value.ToString() });
+                foreach (var kv in securityTokenAccessor.ContextItems)
+                {
+                    contextCollection.Add(kv.Key, new[] { kv.Value.ToString() });
+                }
             }
 
             if (headers != null)

--- a/TestAsyncLocalMiddleware/Infrastructure/ISecurityTokenAccessor.cs
+++ b/TestAsyncLocalMiddleware/Infrastructure/ISecurityTokenAccessor.cs
@@ -7,6 +7,7 @@ namespace TestAsyncLocalMiddleware.Infrastructure
         IDictionary<string, object> ContextItems
         {
             get;
+            set;
         }
     }
 }

--- a/TestAsyncLocalMiddleware/Infrastructure/TokenAuthenticationMiddleware.cs
+++ b/TestAsyncLocalMiddleware/Infrastructure/TokenAuthenticationMiddleware.cs
@@ -53,13 +53,16 @@ namespace TestAsyncLocalMiddleware.Infrastructure
         /// </summary>
         private void PopulateTokenAccessor(IHeaderDictionary headers)
         {
+            var contextItems = new Dictionary<string, object>();
             //CorpId
             if (headers.ContainsKey(AuthCorpIdHeader))
-                _securityTokenAccessor.ContextItems.Add(ContextBuilder.CorpIdHeader, headers[AuthCorpIdHeader].First());
+                contextItems.Add(ContextBuilder.CorpIdHeader, headers[AuthCorpIdHeader].First());
 
             // UserId
             if (headers.ContainsKey(AuthUserHeader))
-                _securityTokenAccessor.ContextItems.Add(ContextBuilder.UserIdHeader, headers[AuthUserHeader].First());
+                contextItems.Add(ContextBuilder.UserIdHeader, headers[AuthUserHeader].First());
+
+            _securityTokenAccessor.ContextItems = contextItems;
 
         }
     }


### PR DESCRIPTION
Values returned are still wrong since the order of resolving the DefaultServiceContext is still backwards but at least now the value is being properly cleared...

To make the example properly work, we would have to make DefaultServiceContext transient....